### PR TITLE
fix(isAllowed): bound to Acl's this

### DIFF
--- a/src/acl.js
+++ b/src/acl.js
@@ -1,6 +1,10 @@
 export class Acl {
   permissions = {};
 
+  constructor() {
+    this.isAllowed = this.isAllowed.bind(this);
+  }
+
   /**
    * Set the permissions object with new permissions
    *


### PR DESCRIPTION
avoids people from having to do

```js
this.isAllowed = this.acl.isAllowed.bind(this.acl);
```

Annoying!